### PR TITLE
fix(Makefile): Correct the new path of the DOCS in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ifdef USE_PGXS
 PGXS := $(shell pg_config --pgxs)
 include $(PGXS)
 else
-subdir = contrib/adviser
+subdir = contrib/pg_adviser
 top_builddir = ../..
 include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk

--- a/index_adviser/Makefile
+++ b/index_adviser/Makefile
@@ -8,7 +8,7 @@ ifdef USE_PGXS
 PGXS := $(shell pg_config --pgxs)
 include $(PGXS)
 else
-subdir = contrib/pgadviser/index_advisor
+subdir = contrib/pg_adviser/index_advisor
 top_builddir = ../../..
 include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk

--- a/index_adviser/Makefile
+++ b/index_adviser/Makefile
@@ -2,7 +2,7 @@
 MODULE_big = index_adviser
 OBJS	= index_adviser.o
 
-DOCS = README.index_adviser
+DOCS = README.txt
 
 ifdef USE_PGXS
 PGXS := $(shell pg_config --pgxs)

--- a/pg_advise/Makefile
+++ b/pg_advise/Makefile
@@ -2,7 +2,7 @@ ifdef USE_PGXS
 PGXS := $(shell pg_config --pgxs)
 include $(PGXS)
 else
-subdir = contrib/pgadviser/pg_advise
+subdir = contrib/pg_adviser/pg_advise
 top_builddir = ../../..
 include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk

--- a/resources/Makefile
+++ b/resources/Makefile
@@ -7,7 +7,7 @@ ifdef USE_PGXS
 PGXS := $(shell pg_config --pgxs)
 include $(PGXS)
 else
-subdir = contrib/pgadviser/resources
+subdir = contrib/pg_adviser/resources
 top_builddir = ../../..
 include $(top_builddir)/src/Makefile.global
 include $(top_srcdir)/contrib/contrib-global.mk

--- a/resources/sample_psql_session.sql
+++ b/resources/sample_psql_session.sql
@@ -17,11 +17,11 @@ drop view if exists select_index_advisory;
 drop function if exists show_index_advisory(index_advisory.backend_pid%type);
 drop table if exists index_advisory;
 
-\i contrib/pgadviser/resources/index_advisory.create.sql
+\i contrib/pg_adviser/resources/index_advisory.create.sql
 
-\i contrib/pgadviser/resources/show_index_advisory.create.sql
+\i contrib/pg_adviser/resources/show_index_advisory.create.sql
 
-\i contrib/pgadviser/resources/select_index_advisory.create.sql
+\i contrib/pg_adviser/resources/select_index_advisory.create.sql
 
 drop table if exists t, t1;
 


### PR DESCRIPTION
# What was done: 
- The [DOCS] in the MakeFile is pointing to a file that's no longer existing `README.index.adviser`, therefore it's causing the installation to fail when 'make'. I replaced it with the new README file `README.txt` and the installation went successfully. 